### PR TITLE
Add CPU load graph to winfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ winfo
 winfo --include-down
 ```
 
+#### Display CPU Load Graph:
+```bash
+winfo --graph
+```
+
 ---
 
 ## Example Workflow

--- a/tests/test_node_info.py
+++ b/tests/test_node_info.py
@@ -1,0 +1,23 @@
+import builtins
+import wrapslurm.node_info as ni
+
+SAMPLE_NODE = """NodeName=hgpn02 Arch=x86_64 CoresPerSocket=16
+   CPUAlloc=32 CPUTot=64 CPULoad=20.00
+   RealMemory=191997 AllocMem=1024
+   State=MIXED
+   Partitions=gpux
+"""
+
+def test_parse_node_data():
+    node = ni.parse_node_data(SAMPLE_NODE)
+    assert node["NodeName"] == "hgpn02"
+    assert node["CPUAlloc"] == 32
+    assert node["CPUTot"] == 64
+    assert abs(node["CPULoad"] - 20.0) < 0.01
+
+def test_display_nodes_graph(capsys):
+    node = ni.parse_node_data(SAMPLE_NODE)
+    ni.display_nodes([node], graph=True)
+    captured = capsys.readouterr().out
+    assert "hgpn02" in captured
+    assert "CPUld" in captured

--- a/wrapslurm/node_info.py
+++ b/wrapslurm/node_info.py
@@ -1,8 +1,20 @@
 import argparse
-from terminaltables import AsciiTable
-from termcolor import colored
 import subprocess
 import re
+
+try:
+    from terminaltables import AsciiTable
+except ImportError:  # pragma: no cover - fallback when dependency missing
+    class AsciiTable:
+        def __init__(self, data):
+            self.table = "\n".join(" | ".join(map(str, row)) for row in data)
+        justify_columns = {}
+
+try:
+    from termcolor import colored
+except ImportError:  # pragma: no cover - fallback to no-op
+    def colored(text, *_args, **_kwargs):
+        return text
 
 
 def get_node_info(include_down=False):
@@ -50,8 +62,10 @@ def parse_node_data(data):
     # Extract CPU details
     cpu_alloc_match = re.search(r"CPUAlloc=(\d+)", data)
     cpu_total_match = re.search(r"CPUTot=(\d+)", data)
+    cpu_load_match = re.search(r"CPULoad=(\S+)", data)
     cpu_alloc = int(cpu_alloc_match.group(1)) if cpu_alloc_match else 0
     cpu_total = int(cpu_total_match.group(1)) if cpu_total_match else 0
+    cpu_load = float(cpu_load_match.group(1)) if cpu_load_match else 0.0
     cpu_usage_percentage = (cpu_alloc / cpu_total) * 100 if cpu_total > 0 else 0
 
     # Extract state
@@ -67,7 +81,10 @@ def parse_node_data(data):
         "State": state,
         "Partitions": partitions,
         "CPUs": f"{cpu_alloc} Alloc ({cpu_usage_percentage:.1f}%) / {cpu_total} Total",
-        "Memory": f"{alloc_memory // 1024} GB Used / {real_memory // 1024} GB ({memory_usage_percentage:.1f}%)"
+        "Memory": f"{alloc_memory // 1024} GB Used / {real_memory // 1024} GB ({memory_usage_percentage:.1f}%)",
+        "CPUAlloc": cpu_alloc,
+        "CPUTot": cpu_total,
+        "CPULoad": cpu_load,
     }
 
 
@@ -86,13 +103,17 @@ def color_state(state):
         return colored(state, "cyan", attrs=["bold"])
 
 
-def display_nodes(nodes):
+def display_nodes(nodes, graph=False):
     """
-    Display node information in a table format.
+    Display node information in a table format. If ``graph`` is True, show a
+    simple CPU usage graph with eight slots per node.
     """
     if not nodes:
         print("No node information to display.")
         return
+
+    if graph:
+        return display_nodes_graph(nodes)
 
     titles = ["NodeName", "State", "Partitions", "CPUs", "Memory"]
 
@@ -111,7 +132,35 @@ def display_nodes(nodes):
         table.justify_columns[i] = "left"
     table.justify_columns[0] = "right"
 
-    print(table.table)
+    output = table.table
+    print(output)
+    return output
+
+
+def display_nodes_graph(nodes, slots=8):
+    """Display nodes with an ASCII CPU usage graph."""
+    titles = ["NodeName"] + [f" #{i+1} " for i in range(slots)] + ["CPUld", "State"]
+
+    rows = []
+    for node in nodes:
+        usage_ratio = node.get("CPUAlloc", 0) / node.get("CPUTot", 1)
+        used = int(round(usage_ratio * slots))
+        bar = ["#" if i < used else " " for i in range(slots)]
+        rows.append([
+            node["NodeName"],
+            *bar,
+            f"{node.get('CPULoad', 0):.2f}",
+            color_state(node["State"]),
+        ])
+
+    table = AsciiTable([titles] + rows)
+    for i in range(len(titles)):
+        table.justify_columns[i] = "left"
+    table.justify_columns[0] = "right"
+
+    output = table.table
+    print(output)
+    return output
 
 
 def main():
@@ -126,10 +175,15 @@ def main():
         action="store_true",
         help="Include nodes in 'down' or 'drain' states."
     )
+    parser.add_argument(
+        "--graph",
+        action="store_true",
+        help="Display nodes with an ASCII CPU load graph."
+    )
     args = parser.parse_args()
 
     try:
         nodes = get_node_info(include_down=args.include_down)
-        display_nodes(nodes)
+        display_nodes(nodes, graph=args.graph)
     except RuntimeError as e:
         print(f"Error: {e}")


### PR DESCRIPTION
## Summary
- provide terminaltables/termcolor fallbacks
- support CPU load graph with `winfo --graph`
- document the new graph option
- add tests for node parser and graph

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687869455a70832a9fef271d9cce8b5a