### PR TITLE
Add wr defaults storage and align log outputs

### DIFF
--- a/wrapslurm/job_runner.py
+++ b/wrapslurm/job_runner.py
@@ -1,7 +1,25 @@
+"""User friendly front-end for submitting SLURM jobs."""
+
 import argparse
+import json
 import os
+import re
+import shlex
 import subprocess
+from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency used for rich tables
+    from terminaltables import AsciiTable
+except ImportError:  # pragma: no cover
+    AsciiTable = None
+
+try:  # pragma: no cover - colour output is optional in tests
+    from termcolor import colored
+except ImportError:  # pragma: no cover
+    def colored(text, *_args, **_kwargs):
+        return text
 
 DEFAULT_SLURM_TEMPLATE = """#!/bin/bash
 #SBATCH -N {nodes}
@@ -12,8 +30,9 @@ DEFAULT_SLURM_TEMPLATE = """#!/bin/bash
 #SBATCH --mem={memory}
 #SBATCH --gres=gpu:{gpus}
 #SBATCH --time={time}
-#SBATCH -o ./slurm-report/%j-slurm.out
-{nodelist_option}{exclude_option}
+#SBATCH -o {report_dir}/%j.out
+#SBATCH -e {report_dir}/%j.err
+{job_name_line}{nodelist_option}{exclude_option}
 
 # SLURM Environment Variables
 echo "SLURM_NNODES=${{SLURM_NNODES}}"
@@ -29,10 +48,72 @@ export CUDA_LAUNCH_BLOCKING=1
 export TORCH_DISTRIBUTED_DEBUG=DETAIL
 
 # Command Execution
-srun --wait=60 --kill-on-bad-exit=1 --mpi=pmix bash -c "{command}"
+srun --wait=60 --kill-on-bad-exit=1 --mpi=pmix bash -lc {command}
 """
 
-def get_default_account():
+
+DEFAULT_REPORT_DIR = "./slurm-report"
+DEFAULT_SCRIPT_DIR = "./slurm_run"
+DEFAULT_TIME = "4-00:00:00"
+DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.expanduser("~"), ".config", "wrapslurm", "defaults.json"
+)
+
+DEFAULT_FIELD_TYPES: Dict[str, type] = {
+    "nodes": int,
+    "tasks_per_node": int,
+    "cpus_per_task": int,
+    "gpus": int,
+}
+
+
+@dataclass
+class JobConfig:
+    """Normalized configuration for a SLURM job submission."""
+
+    nodes: int
+    partition: str
+    account: str
+    tasks_per_node: int
+    cpus_per_task: int
+    memory: str
+    gpus: int
+    time: str
+    report_dir: str
+    command: Sequence[str] = field(default_factory=list)
+    nodelist: Optional[str] = None
+    exclude: Optional[str] = None
+    job_name: Optional[str] = None
+    interactive: bool = False
+
+
+    def command_for_display(self) -> str:
+        if self.interactive:
+            return "Interactive shell"
+        if not self.command:
+            return "<no command provided>"
+        return " ".join(self.command)
+
+    def command_for_script(self) -> str:
+        if not self.command:
+            raise ValueError("Batch jobs require a command to execute.")
+        command_line = shlex.join(self.command)
+        # Quote the entire command so that it is passed as a single argument to bash -lc.
+        return shlex.quote(command_line)
+
+
+@dataclass
+class PartitionInfo:
+    """Summary of a partition's resource limits."""
+
+    name: str
+    cpus_per_node: int
+    memory_mb: int
+    memory_display: str
+    gpus: int
+    max_time: Optional[str]
+
+def get_default_account() -> str:
     try:
         cmd = [
             "sacctmgr",
@@ -47,125 +128,505 @@ def get_default_account():
     except (subprocess.CalledProcessError, FileNotFoundError):
         raise RuntimeError("Unable to retrieve default SLURM account. Ensure 'sacctmgr' is installed.")
 
-def get_node_resources():
+
+def format_memory(memory_mb: int) -> str:
+    if memory_mb <= 0:
+        return "50G"
+    if memory_mb % 1024 == 0:
+        return f"{memory_mb // 1024}G"
+    if memory_mb > 1024:
+        return f"{memory_mb / 1024:.1f}G"
+    return f"{memory_mb}M"
+
+
+def parse_gpus(gres_field: str) -> int:
+    if not gres_field:
+        return 1
+    for entry in gres_field.split(","):
+        if "gpu" not in entry:
+            continue
+        numbers = re.findall(r"(\d+)", entry)
+        if not numbers:
+            continue
+        try:
+            count = int(numbers[-1])
+            return max(1, count)
+        except ValueError:
+            continue
+    return 1
+
+
+def get_default(defaults: Dict[str, object], key: str) -> Optional[object]:
+    if key not in defaults:
+        return None
+    value = defaults[key]
+    target_type = DEFAULT_FIELD_TYPES.get(key)
+    if target_type is not None and value is not None:
+        try:
+            return target_type(value)
+        except (TypeError, ValueError):
+            print(f"Ignoring stored default for {key!r}: {value!r}")
+            return None
+    return value
+
+
+def load_user_defaults(path: str = DEFAULT_CONFIG_PATH) -> Dict[str, object]:
     try:
-        result = subprocess.check_output(["sinfo", "--format=%P|%N|%C|%m", "--noheader"], text=True).strip()
+        with open(path, "r", encoding="utf-8") as config_file:
+            data = json.load(config_file)
+            if isinstance(data, dict):
+                return data
+            print(f"Ignoring malformed defaults at {path}: expected an object")
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        print(f"Ignoring corrupted defaults file at {path}")
+    return {}
+
+
+def save_user_defaults(updates: Dict[str, object], path: str = DEFAULT_CONFIG_PATH) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    defaults = load_user_defaults(path)
+    defaults.update(updates)
+    with open(path, "w", encoding="utf-8") as config_file:
+        json.dump(defaults, config_file, indent=2)
+    print(f"Saved defaults to {path}")
+
+
+def collect_default_updates(args: argparse.Namespace) -> Dict[str, object]:
+    fields = {
+        "partition",
+        "account",
+        "nodes",
+        "tasks_per_node",
+        "cpus_per_task",
+        "memory",
+        "gpus",
+        "time",
+        "report_dir",
+        "script_dir",
+    }
+    updates: Dict[str, object] = {}
+    for field in fields:
+        value = getattr(args, field, None)
+        if value is not None:
+            updates[field] = value
+    return updates
+
+
+def query_partition_resources() -> Dict[str, PartitionInfo]:
+    try:
+        result = subprocess.check_output(
+            ["sinfo", "--format=%P|%c|%m|%G|%l", "--noheader"], text=True
+        ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         raise RuntimeError("Unable to query SLURM resources. Ensure 'sinfo' is installed.")
 
-    best_partition, best_cpus, best_memory, best_gpus = None, 1, "50G", 1
+    partitions: Dict[str, PartitionInfo] = {}
     for line in result.split("\n"):
-        parts = line.split("|")
-        if len(parts) < 4:
+        if not line.strip():
             continue
-        partition, _, cpu_info, memory = parts[:4]
-        partition = partition.split("*")[0].strip()
-        cpus_total = int(cpu_info.split("/")[-1])
-        memory_mb = int("".join(filter(str.isdigit, memory))) if memory else 0
-        memory_gb = f"{memory_mb // 1024}G" if memory_mb > 0 else "50G"
-        if not best_partition or cpus_total > best_cpus:
-            best_partition, best_cpus, best_memory = partition, cpus_total, memory_gb
-    return best_partition, 1, best_cpus, best_memory, best_gpus
+        parts = line.split("|")
+        if len(parts) < 5:
+            continue
+        partition_name_raw, cpu_info, memory_raw, gres, max_time = parts[:5]
+        partition_name = partition_name_raw.split("*")[0].strip()
+        if not partition_name:
+            continue
+        cpu_pieces = [piece for piece in cpu_info.split("/") if piece]
+        try:
+            cpus_total = int(cpu_pieces[-1]) if cpu_pieces else 1
+        except ValueError:
+            cpus_total = 1
+        memory_digits = "".join(filter(str.isdigit, memory_raw))
+        try:
+            memory_mb = int(memory_digits) if memory_digits else 0
+        except ValueError:
+            memory_mb = 0
+        memory_display = format_memory(memory_mb)
+        gpus = parse_gpus(gres)
+        partition_info = partitions.get(partition_name)
+        if partition_info is None or cpus_total > partition_info.cpus_per_node:
+            partitions[partition_name] = PartitionInfo(
+                name=partition_name,
+                cpus_per_node=cpus_total,
+                memory_mb=memory_mb,
+                memory_display=memory_display,
+                gpus=gpus,
+                max_time=max_time.strip() or None,
+            )
+    return partitions
 
-def generate_sbatch_script(args):
-    if not all([args.partition, args.nodes, args.cpus_per_task, args.memory]):
-        best_partition, best_nodes, best_cpus, best_memory, best_gpus = get_node_resources()
-        args.partition = args.partition or best_partition
-        args.nodes = args.nodes or best_nodes
-        args.cpus_per_task = args.cpus_per_task or best_cpus
-        args.memory = args.memory or best_memory
-        args.gpus = args.gpus or best_gpus
-
-    args.account = args.account or get_default_account()
-    nodelist_option = f"#SBATCH --nodelist={args.nodelist}\n" if args.nodelist else ""
-    exclude_option = f"#SBATCH --exclude={args.exclude}\n" if args.exclude else ""
-
-    sbatch_script = DEFAULT_SLURM_TEMPLATE.format(
-        nodes=args.nodes,
-        partition=args.partition,
-        account=args.account,
-        tasks_per_node=args.tasks_per_node,
-        cpus_per_task=args.cpus_per_task,
-        memory=args.memory,
-        gpus=args.gpus,
-        time=args.time,
+def build_sbatch_script(config: JobConfig) -> str:
+    nodelist_option = f"#SBATCH --nodelist={config.nodelist}\n" if config.nodelist else ""
+    exclude_option = f"#SBATCH --exclude={config.exclude}\n" if config.exclude else ""
+    job_name_line = f"#SBATCH -J {config.job_name}\n" if config.job_name else ""
+    return DEFAULT_SLURM_TEMPLATE.format(
+        nodes=config.nodes,
+        partition=config.partition,
+        account=config.account,
+        tasks_per_node=config.tasks_per_node,
+        cpus_per_task=config.cpus_per_task,
+        memory=config.memory,
+        gpus=config.gpus,
+        time=config.time,
+        report_dir=config.report_dir,
         nodelist_option=nodelist_option,
         exclude_option=exclude_option,
-        command=args.command,
+        job_name_line=job_name_line,
+        command=config.command_for_script(),
     )
+
+
+def generate_sbatch_script(config: JobConfig, script_dir: str) -> str:
+    sbatch_script = build_sbatch_script(config)
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     script_name = f"job_{timestamp}.sbatch"
-    script_path = os.path.join(os.getcwd(), './slurm_run/', script_name)
+    script_path = os.path.join(os.getcwd(), script_dir, script_name)
 
     os.makedirs(os.path.dirname(script_path), exist_ok=True)
-    with open(script_path, "w") as f:
+    with open(script_path, "w", encoding="utf-8") as f:
         f.write(sbatch_script)
     print(f"Generated sbatch script: {script_path}")
     return script_path
 
-def submit_sbatch(script_path):
-    report_dir = "./slurm-report"
+
+def submit_sbatch(script_path: str, report_dir: str) -> None:
     os.makedirs(report_dir, exist_ok=True)
     try:
         result = subprocess.run(["sbatch", script_path], capture_output=True, text=True, check=True)
         job_id = result.stdout.strip().split()[-1]
         print(f"Job submitted: {result.stdout.strip()}")
-        print(f"Monitor logs: watch tail -n 20 {os.path.join(report_dir, f'{job_id}-slurm.out')}")
+        stdout_log = os.path.join(report_dir, f"{job_id}.out")
+        stderr_log = os.path.join(report_dir, f"{job_id}.err")
+        print(f"Stdout log: {stdout_log}")
+        print(f"Stderr log: {stderr_log}")
+        print(f"Monitor logs: tail -n 20 -f {stdout_log}")
     except subprocess.CalledProcessError as e:
         print(f"Error submitting job: {e.stderr.strip()}")
 
-def run_interactive(args):
-    if not all([args.partition, args.nodes, args.cpus_per_task, args.memory]):
-        best_partition, best_nodes, best_cpus, best_memory, best_gpus = get_node_resources()
-        args.partition = args.partition or best_partition
-        args.nodes = args.nodes or best_nodes
-        args.cpus_per_task = args.cpus_per_task or best_cpus
-        args.memory = args.memory or best_memory
-        args.gpus = args.gpus or best_gpus
-
-    args.account = args.account or get_default_account()
+def run_interactive(config: JobConfig) -> None:
     srun_cmd = [
         "srun",
-        f"--partition={args.partition}",
-        f"--account={args.account}",
-        f"-N {args.nodes}",
-        f"--ntasks-per-node={args.tasks_per_node}",
-        f"--cpus-per-task={args.cpus_per_task}",
-        f"--mem={args.memory}",
-        f"--gres=gpu:{args.gpus}",
-        f"--time={args.time}",
+        f"--partition={config.partition}",
+        f"--account={config.account}",
+        f"-N {config.nodes}",
+        f"--ntasks-per-node={config.tasks_per_node}",
+        f"--cpus-per-task={config.cpus_per_task}",
+        f"--mem={config.memory}",
+        f"--gres=gpu:{config.gpus}",
+        f"--time={config.time}",
         "--pty",
         "bash"
     ]
-    if args.nodelist:
-        srun_cmd.insert(-2, f"--nodelist={args.nodelist}")
-    if args.exclude:
-        srun_cmd.insert(-2, f"--exclude={args.exclude}")
+    if config.nodelist:
+        srun_cmd.insert(-2, f"--nodelist={config.nodelist}")
+    if config.exclude:
+        srun_cmd.insert(-2, f"--exclude={config.exclude}")
     print(f"Starting interactive session with: {' '.join(srun_cmd)}")
     subprocess.run(srun_cmd)
 
-def main():
-    parser = argparse.ArgumentParser(description="SLURM job manager.")
-    parser.add_argument("--nodes", type=int, help="Number of nodes")
-    parser.add_argument("--partition", help="Partition name")
-    parser.add_argument("--account", help="SLURM account")
-    parser.add_argument("--tasks-per-node", type=int, default=1, help="Tasks per node")
-    parser.add_argument("--cpus-per-task", type=int, default=10, help="CPU cores per task")
+def highlight_value(
+    value: str,
+    field: str,
+    auto_fields: Iterable[str],
+    default_fields: Iterable[str],
+) -> str:
+    if field in auto_fields:
+        return colored(f"{value} *", "cyan")
+    if field in default_fields:
+        return colored(f"{value} \u2020", "yellow")
+    return str(value)
+
+
+def print_job_summary(
+    config: JobConfig,
+    auto_fields: Iterable[str],
+    default_fields: Iterable[str],
+    mode: str,
+    script_path: Optional[str] = None,
+) -> None:
+    rows = [
+        ("Mode", mode),
+        (
+            "Partition",
+            highlight_value(config.partition, "partition", auto_fields, default_fields),
+        ),
+        ("Account", highlight_value(config.account, "account", auto_fields, default_fields)),
+        ("Nodes", highlight_value(config.nodes, "nodes", auto_fields, default_fields)),
+        (
+            "Tasks / Node",
+            highlight_value(
+                config.tasks_per_node,
+                "tasks_per_node",
+                auto_fields,
+                default_fields,
+            ),
+        ),
+        (
+            "CPUs / Task",
+            highlight_value(
+                config.cpus_per_task,
+                "cpus_per_task",
+                auto_fields,
+                default_fields,
+            ),
+        ),
+        ("Memory", highlight_value(config.memory, "memory", auto_fields, default_fields)),
+        ("GPUs", highlight_value(config.gpus, "gpus", auto_fields, default_fields)),
+        ("Time", highlight_value(config.time, "time", auto_fields, default_fields)),
+        ("Command", config.command_for_display()),
+    ]
+
+    if config.nodelist:
+        rows.append(("NodeList", config.nodelist))
+    if config.exclude:
+        rows.append(("Exclude", config.exclude))
+    if config.job_name:
+        rows.append(("Job Name", config.job_name))
+    rows.append(
+        ("Log Dir", highlight_value(config.report_dir, "report_dir", auto_fields, default_fields))
+    )
+    if script_path:
+        rows.append(("Script", script_path))
+
+    if AsciiTable:
+        table = AsciiTable([["Setting", "Value"]] + list(rows))
+        table.justify_columns[0] = "right"
+        for col in range(1, len(table.table_data[0])):
+            table.justify_columns[col] = "left"
+        print(table.table)
+    else:  # pragma: no cover - fallback formatting for missing dependency
+        for setting, value in rows:
+            print(f"{setting:>12}: {value}")
+
+    if auto_fields:
+        print(colored("* Automatically detected value", "cyan"))
+    if default_fields:
+        print(colored("† Loaded from saved defaults", "yellow"))
+
+
+def resolve_job_config(
+    args: argparse.Namespace, defaults: Dict[str, object]
+) -> Tuple[JobConfig, List[str], List[str], str]:
+    auto_fields: List[str] = []
+    default_fields: List[str] = []
+
+    def use_default(current_value: Optional[object], key: str) -> Optional[object]:
+        if current_value is not None:
+            return current_value
+        default_value = get_default(defaults, key)
+        if default_value is not None:
+            default_fields.append(key)
+        return default_value
+
+    partition = use_default(args.partition, "partition")
+    nodes = use_default(args.nodes, "nodes")
+    tasks_per_node = use_default(args.tasks_per_node, "tasks_per_node")
+    cpus_per_task = use_default(args.cpus_per_task, "cpus_per_task")
+    memory = use_default(args.memory, "memory")
+    gpus = use_default(args.gpus, "gpus")
+    time = use_default(args.time, "time")
+    report_dir = use_default(args.report_dir, "report_dir") or DEFAULT_REPORT_DIR
+    script_dir = use_default(args.script_dir, "script_dir") or DEFAULT_SCRIPT_DIR
+
+    partition_infos: Dict[str, PartitionInfo] = {}
+    partition_info: Optional[PartitionInfo] = None
+
+    need_partition_data = (
+        partition is None
+        or cpus_per_task is None
+        or memory is None
+        or gpus is None
+        or time is None
+    )
+
+    if need_partition_data:
+        try:
+            partition_infos = query_partition_resources()
+        except RuntimeError as exc:
+            if partition is None or cpus_per_task is None or memory is None or gpus is None:
+                raise RuntimeError(str(exc))
+
+    if partition is None:
+        if not partition_infos:
+            raise RuntimeError(
+                "Unable to determine partition. Provide --partition or ensure 'sinfo' is available."
+            )
+        partition_info = max(
+            partition_infos.values(),
+            key=lambda info: (info.cpus_per_node, info.gpus, info.memory_mb),
+        )
+        partition = partition_info.name
+        auto_fields.append("partition")
+    else:
+        partition_info = partition_infos.get(str(partition)) if partition_infos else None
+
+    if nodes is None:
+        nodes = 1
+        auto_fields.append("nodes")
+
+    if tasks_per_node is None:
+        tasks_per_node = 1
+        auto_fields.append("tasks_per_node")
+
+    if cpus_per_task is None:
+        if partition_info is None:
+            raise RuntimeError(
+                "Unable to determine CPUs per task. Provide --cpus-per-task or ensure 'sinfo' is available."
+            )
+        cpus_per_task = partition_info.cpus_per_node
+        auto_fields.append("cpus_per_task")
+
+    if memory is None:
+        if partition_info is None:
+            raise RuntimeError(
+                "Unable to determine memory. Provide --memory or ensure 'sinfo' is available."
+            )
+        memory = partition_info.memory_display
+        auto_fields.append("memory")
+
+    if gpus is None:
+        if partition_info is not None:
+            gpus = partition_info.gpus
+        else:
+            gpus = 1
+        auto_fields.append("gpus")
+
+    if time is None:
+        if partition_info is not None and partition_info.max_time:
+            time = partition_info.max_time
+        else:
+            time = DEFAULT_TIME
+        auto_fields.append("time")
+
+    try:
+        account = use_default(args.account, "account")
+        if account is None:
+            account = get_default_account()
+            auto_fields.append("account")
+    except RuntimeError as exc:
+        raise RuntimeError(str(exc))
+
+    command_parts: Sequence[str] = list(args.command or [])
+    interactive = args.interactive
+    if not command_parts:
+        interactive = True
+    elif len(command_parts) == 1 and command_parts[0].strip() == "bash":
+        interactive = True
+
+    config = JobConfig(
+        nodes=int(nodes),
+        partition=str(partition),
+        account=str(account),
+        tasks_per_node=int(tasks_per_node),
+        cpus_per_task=int(cpus_per_task),
+        memory=str(memory),
+        gpus=int(gpus),
+        time=str(time),
+        report_dir=str(report_dir),
+        command=command_parts,
+        nodelist=args.nodelist,
+        exclude=args.exclude,
+        job_name=args.job_name,
+        interactive=interactive,
+    )
+
+    return config, auto_fields, default_fields, script_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Submit and manage SLURM jobs with sensible defaults and friendly output.",
+    )
+    parser.add_argument("--nodes", type=int, help="Number of nodes to request")
+    parser.add_argument("--partition", help="Partition name to submit to")
+    parser.add_argument("--account", help="SLURM account to charge")
+    parser.add_argument(
+        "--tasks-per-node",
+        type=int,
+        help="Tasks per node (default: 1)",
+    )
+    parser.add_argument("--cpus-per-task", type=int, help="CPU cores per task")
     parser.add_argument("--memory", help="Memory per node (e.g., 50G)")
     parser.add_argument("--gpus", type=int, help="GPUs per node")
-    parser.add_argument("--time", default="4-00:00:00", help="Job time limit")
-    parser.add_argument("--nodelist", help="Nodes to include")
-    parser.add_argument("--exclude", help="Nodes to exclude")
-    parser.add_argument("--interactive", action="store_true", help="Start an interactive session")
-    parser.add_argument("command", nargs="?", default="", help="Command to execute")
+    parser.add_argument(
+        "--time",
+        help="Job time limit (default: partition maximum when available)",
+    )
+    parser.add_argument("--nodelist", help="Comma separated list of nodes to include")
+    parser.add_argument("--exclude", help="Comma separated list of nodes to exclude")
+    parser.add_argument("--job-name", help="Optional job name shown in SLURM accounting")
+    parser.add_argument(
+        "--report-dir",
+        help=f"Directory where SLURM outputs logs (default: {DEFAULT_REPORT_DIR})",
+    )
+    parser.add_argument(
+        "--script-dir",
+        help=f"Directory to store generated sbatch scripts (default: {DEFAULT_SCRIPT_DIR})",
+    )
+    parser.add_argument("--interactive", action="store_true", help="Force an interactive srun session")
+    parser.add_argument("--dry-run", action="store_true", help="Show the sbatch script without submitting")
+    parser.add_argument(
+        "--save-defaults",
+        action="store_true",
+        help="Persist the provided options as defaults and exit",
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to execute for batch jobs (e.g. python train.py --epochs 10)",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
-    if args.interactive or args.command.strip() == "bash":
-        run_interactive(args)
-    else:
-        script_path = generate_sbatch_script(args)
-        submit_sbatch(script_path)
+    defaults = load_user_defaults()
+
+    if args.save_defaults:
+        updates = collect_default_updates(args)
+        if updates:
+            save_user_defaults(updates)
+        else:
+            print("No values provided to save as defaults.")
+        return
+
+    try:
+        config, auto_fields, default_fields, script_dir = resolve_job_config(args, defaults)
+    except RuntimeError as exc:
+        print(f"Error: {exc}")
+        return
+
+    mode = "Interactive" if config.interactive else "Batch"
+
+    if config.interactive:
+        print_job_summary(config, auto_fields, default_fields, mode)
+        run_interactive(config)
+        return
+
+    if args.dry_run:
+        try:
+            script_content = build_sbatch_script(config)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            return
+        print_job_summary(config, auto_fields, default_fields, mode)
+        print("\nDry run enabled – sbatch script preview:\n")
+        print(script_content)
+        return
+
+    try:
+        script_path = generate_sbatch_script(config, script_dir)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return
+
+    print_job_summary(config, auto_fields, default_fields, mode, script_path=script_path)
+    submit_sbatch(script_path, config.report_dir)
 
 if __name__ == "__main__":
     main()

--- a/wrapslurm/track_job.py
+++ b/wrapslurm/track_job.py
@@ -24,11 +24,11 @@ def find_latest_log(report_dir="./slurm-report"):
 
 def watch_log(log_file):
     """
-    Watch the specified log file using `watch` and `tail`.
+    Follow the specified log file using ``tail -f``.
     """
     try:
         print(f"Watching log file: {log_file}")
-        subprocess.run(["watch", "tail", "-n", "20", log_file])
+        subprocess.run(["tail", "-n", "20", "-f", log_file])
     except KeyboardInterrupt:
         print("\nStopped watching log.")
     except Exception as e:
@@ -47,7 +47,7 @@ def main():
 
     if args.job_id:
         # Construct the log file path for the specific job ID
-        log_file = os.path.join(args.report_dir, f"{args.job_id}-slurm.out")
+        log_file = os.path.join(args.report_dir, f"{args.job_id}.out")
         if not os.path.exists(log_file):
             print(f"Error: Log file for job ID {args.job_id} not found in {args.report_dir}")
             exit(1)


### PR DESCRIPTION
## Summary
- allow `wr` to persist user defaults and show them in the job summary
- derive partition limits from `sinfo`, default `--time` to the partition maximum, and write logs to `%j.out` / `%j.err`
- update the README and `wlog` tracker to document the new defaults flow and log locations

## Testing
- ✅ `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_6903a6a46bbc83209df50089e62f4b38